### PR TITLE
Mobile time selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "swecc-client",
       "version": "0.0.0",
       "dependencies": {
+        "@chakra-ui/icons": "^2.1.1",
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
@@ -542,6 +543,18 @@
       "integrity": "sha512-xxjGLvlX2Ys4H0iHrI16t74rG9EBcpFvJ3Y3B7KMQTrnW34Kf7Da/UC8J67Gtx85mTHW020ml85SVPKORWNNKQ==",
       "dependencies": {
         "@chakra-ui/shared-utils": "2.0.5"
+      },
+      "peerDependencies": {
+        "@chakra-ui/system": ">=2.0.0",
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.1.1.tgz",
+      "integrity": "sha512-3p30hdo4LlRZTT5CwoAJq3G9fHI0wDc0pBaMHj4SUn0yomO+RcDRlzhdXqdr5cVnzax44sqXJVnf3oQG0eI+4g==",
+      "dependencies": {
+        "@chakra-ui/icon": "3.2.0"
       },
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.1.1",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",

--- a/src/components/InterviewSignupForm.tsx
+++ b/src/components/InterviewSignupForm.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react'
 import { Box, Button, Heading, VStack } from '@chakra-ui/react'
 import ChakaraTimeRangeSelector from './TimeRangeSelector/ChakaraTimeRangeSelector'
+import MobileTimeRangeSelector from './TimeRangeSelector/MobileTimeRangeSelector'
 import { motion, AnimatePresence } from 'framer-motion'
 import ConfirmInterviewSignupStep from './ConfirmInterviewSignupStep'
 import { updateInterviewAvailabilityForUser } from '../services/mock/interview'
 import { useMember } from '../context/MemberContex'
 import { InterviewAvailability } from '../types'
+
 
 const getNextSunday = () => {
   const today = new Date()
@@ -31,6 +33,9 @@ const InterviewSignupForm: React.FC<InterviewSignupFormProps> = ({
   const { member } = useMember()
   const [currentStep, setCurrentStep] = useState(0)
   const steps = ['Availability', 'Confirmation']
+
+  const isMobile = window.innerWidth < 768
+  console.log('isMobile', isMobile)
 
   const handleNext = () => {
     setCurrentStep(prev => Math.min(prev + 1, steps.length - 1))
@@ -69,7 +74,17 @@ const InterviewSignupForm: React.FC<InterviewSignupFormProps> = ({
   const renderStep = (step: number) => {
     switch (step) {
       case 0:
-        return (
+        return isMobile
+        ? (
+          <MobileTimeRangeSelector
+            title={title}
+            availability={availability}
+            onChange={onChange}
+            dayLabels={dayLabels}
+            timeLabels={timeLabels}
+          />
+        )
+        : (
           <ChakaraTimeRangeSelector
             title={title}
             availability={availability}

--- a/src/components/TimeRangeSelector/MobileTimeRangeSelector.tsx
+++ b/src/components/TimeRangeSelector/MobileTimeRangeSelector.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import {
+  VStack,
+  HStack,
+  Box,
+  Text,
+  Button,
+  useColorModeValue,
+} from '@chakra-ui/react';
+
+interface MobileTimeRangeSelectorProps {
+  availability: boolean[][];
+  onChange: (newAvailability: boolean[][]) => void;
+  title: string;
+  dayLabels?: string[];
+  timeLabels?: string[];
+}
+
+const defaultDayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const defaultTimeLabels = Array.from({ length: 48 }, (_, i) => {
+  const hour = Math.floor(i / 2);
+  const minutes = i % 2 === 0 ? '00' : '30';
+  return `${hour.toString().padStart(2, '0')}:${minutes}`;
+});
+
+const MobileTimeRangeSelector: React.FC<MobileTimeRangeSelectorProps> = ({
+  availability,
+  onChange,
+  title,
+  dayLabels = defaultDayLabels,
+  timeLabels = defaultTimeLabels,
+}) => {
+  const [selectedDayIndex, setSelectedDayIndex] = useState<number | null>(null);
+  const [selectedSlots, setSelectedSlots] = useState<boolean[][]>(availability);
+
+  const toggleTimeSlot = (dayIndex: number, timeIndex: number) => {
+    const newSlots = selectedSlots.map((day, i) =>
+      i === dayIndex
+        ? day.map((slot, j) => (j === timeIndex ? !slot : slot))
+        : day
+    );
+    setSelectedSlots(newSlots);
+    onChange(newSlots);
+  };
+
+  const handleDayClick = (index: number) => {
+    setSelectedDayIndex(index === selectedDayIndex ? null : index);
+  };
+
+  const bgColor = useColorModeValue('white', 'gray.800');
+  const textColor = useColorModeValue('gray.800', 'white');
+  const borderColor = useColorModeValue('gray.200', 'gray.600');
+
+  return (
+    <VStack spacing={4} align="stretch" w="100%" bg={bgColor} p={4}>
+      <Text fontSize="2xl" fontWeight="bold" textAlign="center" color={textColor}>
+        {title}
+      </Text>
+      {dayLabels.map((day, dayIndex) => (
+        <Box
+          key={day}
+          borderWidth="1px"
+          borderRadius="lg"
+          borderColor={borderColor}
+          w="100%"
+          p={3}
+        >
+          <Text
+            fontSize="lg"
+            fontWeight="medium"
+            onClick={() => handleDayClick(dayIndex)}
+            cursor="pointer"
+            color={textColor}
+          >
+            {day}
+          </Text>
+          {selectedDayIndex === dayIndex && (
+            <VStack spacing={2} mt={3}>
+              {timeLabels.map((time, timeIndex) => (
+                <HStack key={time} w="100%" justifyContent="space-between">
+                  <Text fontSize="sm" width="80px">
+                    {time}
+                  </Text>
+                  <Button
+                    size="sm"
+                    colorScheme={selectedSlots[dayIndex][timeIndex] ? 'teal' : 'gray'}
+                    onClick={() => toggleTimeSlot(dayIndex, timeIndex)}
+                    flex={1}
+                  >
+                    {selectedSlots[dayIndex][timeIndex] ? 'Available' : 'Unavailable'}
+                  </Button>
+                </HStack>
+              ))}
+            </VStack>
+          )}
+        </Box>
+      ))}
+    </VStack>
+  );
+};
+
+export default MobileTimeRangeSelector;


### PR DESCRIPTION
Author: Elijah

## What changes were made?

Added a mobile version of the TimeRangeSelector component

## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!

before
<img width="434" alt="Screenshot 2024-08-10 at 1 19 40 PM" src="https://github.com/user-attachments/assets/c61322bc-a2db-456d-a611-6b89148a4e86">

after
<img width="425" alt="Screenshot 2024-08-10 at 1 20 06 PM" src="https://github.com/user-attachments/assets/0f01e1ec-9baf-487f-a2a6-035c0754e9f4">
