### PR TITLE
Update the command as it's /auth username not /auth userid

### DIFF
--- a/src/components/DiscordVerification.tsx
+++ b/src/components/DiscordVerification.tsx
@@ -15,10 +15,12 @@ import { CheckCircleIcon } from '@chakra-ui/icons';
 
 interface DiscordVerificationProps {
   userId: number;
+  username: string;
 }
 
 const DiscordVerification: React.FC<DiscordVerificationProps> = ({
   userId,
+  username
 }) => {
   const [verificationCode, setVerificationCode] = useState('');
   const [isVerified, setIsVerified] = useState(false);
@@ -87,7 +89,7 @@ const DiscordVerification: React.FC<DiscordVerificationProps> = ({
               <Text fontSize="lg">
                 Run{' '}
                 <Text as="span" fontWeight="bold">
-                  `/auth {userId}`
+                  `/auth {username}`
                 </Text>{' '}
                 in the Discord server and paste the code here.
               </Text>

--- a/src/pages/AuthPage.tsx
+++ b/src/pages/AuthPage.tsx
@@ -80,7 +80,7 @@ const AuthPage: React.FC = () => {
             width="full"
           >
             {isRegistered && userId ? (
-              <DiscordVerification userId={userId} />
+              <DiscordVerification username={username} userId={userId} />
             ) : (
               <Tabs isFitted variant="enclosed">
                 <TabList mb="1em">


### PR DESCRIPTION
Author: Shawn

## What changes were made?
Update the text when registering to instruct to type /auth username instead of /auth userid since that's what the command is

## Why are these changes important/necessary?
The previous display was incorrect.
