### PR TITLE
Fixed the auth message to be /verify instead of /auth

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -109,7 +109,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       'Your account does not have a Discord ID associated with it.'
     ) {
       setError(
-        `Your discord is not verified. Please type /auth ${errorData.username} in the swecc server`
+        `Your discord is not verified. Please type /verify in the swecc server and enter ${errorData.username}`
       );
     } else {
       setError('Invalid credentials. Please try again.');


### PR DESCRIPTION
Author: shawn

## What changes were made?
when getting the error you aren't verified it told people to type /auth instead of /verify.

## Why are these changes important/necessary?

## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!
