### PR TITLE
hide status and enhanced report popup

### DIFF
--- a/src/components/ReportPopUp.tsx
+++ b/src/components/ReportPopUp.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
-import { ReportBody } from '../types';
+import { ReportBody, ReportType } from '../types';
 import {
   Badge,
-  Box,
   Button,
   Card,
   CardBody,
@@ -12,22 +11,24 @@ import {
   FormLabel,
   Heading,
   Stack,
-  Text,
   Textarea,
   VStack,
   useToast,
 } from '@chakra-ui/react';
 import { createReport } from '../services/report';
 import { devPrint } from './utils/RandomUtils';
+import { CloseIcon } from '@chakra-ui/icons';
 
 interface ReportPopUpProps {
   associatedId: string;
   reporterUserId?: number;
+  type: ReportType;
   onClose: () => void;
 }
 
 const ReportPopUp: React.FC<ReportPopUpProps> = ({
   associatedId,
+  type,
   reporterUserId,
   onClose,
 }) => {
@@ -37,7 +38,7 @@ const ReportPopUp: React.FC<ReportPopUpProps> = ({
   const [formData, setFormData] = useState<ReportBody>({
     associatedId: associatedId,
     reporterUserId: reporterUserId,
-    type: 'interview',
+    type: type,
     reason: '',
   });
 
@@ -58,7 +59,11 @@ const ReportPopUp: React.FC<ReportPopUpProps> = ({
     setIsLoading(true);
 
     try {
-      const res = await createReport(formData);
+      const res = await createReport({
+        ...formData,
+        associatedId,
+        reporterUserId,
+      });
 
       toast({
         title: 'Report submitted successfully',
@@ -83,105 +88,99 @@ const ReportPopUp: React.FC<ReportPopUpProps> = ({
   };
 
   return (
-    <Box p={4} maxH="800px" mx="auto" boxSize="xl">
-      <Card variant="outline" boxShadow="lg" borderRadius="lg">
-        <CardHeader pb={0}>
-          <Heading size="md" color="blue.600">
-            Submit Report
-          </Heading>
-        </CardHeader>
+    <Card variant="outline" boxShadow="lg" borderRadius="lg">
+      <Button
+        position="absolute"
+        top={2}
+        right={2}
+        onClick={onClose}
+        variant="ghost"
+      >
+        <CloseIcon />
+      </Button>
+      <CardHeader pb={0}>
+        <Heading size="md" color="blue.600">
+          Submit Report
+        </Heading>
+      </CardHeader>
 
-        <CardBody maxH="500px">
-          <form onSubmit={handleSubmit}>
-            <VStack spacing={2} align="stretch">
-              <Stack spacing={4}>
-                <FormControl>
-                  <FormLabel color="gray.700" fontWeight="medium">
-                    Associated ID
-                  </FormLabel>
-                  <Box
-                    p={3}
-                    bg="gray.50"
-                    borderRadius="md"
-                    border="1px"
-                    borderColor="gray.200"
-                  >
-                    <Text color="gray.700" fontSize="md">
-                      {associatedId}
-                    </Text>
-                  </Box>
-                </FormControl>
-
-                <FormControl>
-                  <FormLabel color="gray.700" fontWeight="medium">
-                    Reporter User ID
-                  </FormLabel>
-                  <Box
-                    p={3}
-                    bg="gray.50"
-                    borderRadius="md"
-                    border="1px"
-                    borderColor="gray.200"
-                  >
-                    <Badge colorScheme="blue" fontSize="md">
-                      {reporterUserId}
-                    </Badge>
-                  </Box>
-                </FormControl>
+      <CardBody maxH="500px">
+        <form onSubmit={handleSubmit}>
+          <VStack spacing={2} align="stretch">
+            <FormControl isRequired isDisabled={isLoading}>
+              <FormLabel color="gray.700" fontWeight="medium">
+                Report Type
+              </FormLabel>
+              <Stack direction="row" spacing={4}>
+                <Badge
+                  colorScheme="red"
+                  variant={formData.type === 'interview' ? 'solid' : 'outline'}
+                  cursor="pointer"
+                  onClick={() =>
+                    setFormData({ ...formData, type: 'interview' })
+                  }
+                >
+                  Interview
+                </Badge>
+                <Badge
+                  colorScheme="red"
+                  variant={formData.type === 'question' ? 'solid' : 'outline'}
+                  cursor="pointer"
+                  onClick={() => setFormData({ ...formData, type: 'question' })}
+                >
+                  Question
+                </Badge>
               </Stack>
+              <Divider my={4} />
 
-              <Divider />
-
-              <FormControl isRequired isDisabled={isLoading}>
-                <FormLabel color="gray.700" fontWeight="medium">
-                  Reason for Report
-                </FormLabel>
-                <Textarea
-                  value={formData.reason}
-                  onChange={handleChange}
-                  placeholder="Please provide detailed information about your report..."
-                  size="lg"
-                  minH="150px"
-                  name="reason"
-                  id="reason"
-                  bg="white"
-                  border="1px"
-                  borderColor="gray.300"
-                  _hover={{
-                    borderColor: 'blue.400',
-                  }}
-                  _focus={{
-                    borderColor: 'blue.500',
-                    boxShadow: '0 0 0 1px var(--chakra-colors-blue-500)',
-                  }}
-                />
-              </FormControl>
-
-              <Button
-                type="submit"
-                colorScheme="blue"
+              <FormLabel color="gray.700" fontWeight="medium">
+                Reason for Report
+              </FormLabel>
+              <Textarea
+                value={formData.reason}
+                onChange={handleChange}
+                placeholder="Please provide detailed information about your report..."
                 size="lg"
-                width="full"
-                mt={4}
-                fontWeight="medium"
-                isLoading={isLoading}
-                loadingText="Submitting..."
+                minH="150px"
+                name="reason"
+                id="reason"
+                bg="white"
+                border="1px"
+                borderColor="gray.300"
                 _hover={{
-                  transform: 'translateY(-1px)',
-                  boxShadow: 'lg',
+                  borderColor: 'blue.400',
                 }}
-                transition="all 0.2s"
-              >
-                Submit Report
-              </Button>
-              <Button variant="ghost" onClick={onClose}>
-                Cancel
-              </Button>
-            </VStack>
-          </form>
-        </CardBody>
-      </Card>
-    </Box>
+                _focus={{
+                  borderColor: 'blue.500',
+                  boxShadow: '0 0 0 1px var(--chakra-colors-blue-500)',
+                }}
+              />
+            </FormControl>
+
+            <Button
+              type="submit"
+              colorScheme="blue"
+              size="lg"
+              width="full"
+              mt={4}
+              fontWeight="medium"
+              isLoading={isLoading}
+              loadingText="Submitting..."
+              _hover={{
+                transform: 'translateY(-1px)',
+                boxShadow: 'lg',
+              }}
+              transition="all 0.2s"
+            >
+              Submit Report
+            </Button>
+            <Button variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+          </VStack>
+        </form>
+      </CardBody>
+    </Card>
   );
 };
 

--- a/src/feature-flag.ts
+++ b/src/feature-flag.ts
@@ -1,0 +1,1 @@
+export const DISABLE_INTERVIEW_STATUS_FLAG = true;

--- a/src/pages/ViewInterviewPage.tsx
+++ b/src/pages/ViewInterviewPage.tsx
@@ -20,6 +20,7 @@ import {
   ModalContent,
   ModalOverlay,
   Button,
+  Flex,
 } from '@chakra-ui/react';
 import { Calendar, Clock, User, Book } from 'lucide-react';
 import { HydratedInterview, Member } from '../types';
@@ -28,6 +29,7 @@ import ReportPopUp from '../components/ReportPopUp';
 import { useAuth } from '../hooks/useAuth';
 import TechnicalQuestionCard from '../components/TechnicalQuestionCard';
 import { useState } from 'react';
+import { DISABLE_INTERVIEW_STATUS_FLAG } from '../feature-flag';
 
 const InterviewView = ({ interview }: { interview: HydratedInterview }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -95,51 +97,63 @@ const InterviewView = ({ interview }: { interview: HydratedInterview }) => {
             associatedId={interview.interviewId}
             reporterUserId={member?.id}
             onClose={onClose}
+            type="interview"
           />
         </ModalContent>
       </Modal>
-      <Grid templateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }} gap={4}>
-        <GridItem>
-          <HStack>
-            <Calendar size={16} />
-            <Text fontSize="sm" color={subtleColor}>
-              scheduled for
-            </Text>
-          </HStack>
-          <Text fontSize="lg" fontWeight="medium">
-            {startDateStr} to
-          </Text>
-          <Text fontSize="lg" fontWeight="medium">
-            {endDateStr}
-          </Text>
-        </GridItem>
-        {dateCompleted && (
-          <GridItem>
-            <HStack>
-              <Clock size={16} />
-              <Text fontSize="sm" color={subtleColor}>
-                completed on
+
+      <Flex width="100%" align="flex-start" justify="space-between">
+        <Box flex="1">
+          <Grid templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)' }} gap={4}>
+            <GridItem>
+              <HStack>
+                <Calendar size={16} />
+                <Text fontSize="sm" color={subtleColor}>
+                  scheduled for
+                </Text>
+              </HStack>
+              <Text fontSize="lg" fontWeight="medium">
+                {startDateStr} to
               </Text>
-            </HStack>
-            <Text fontSize="lg" fontWeight="medium">
-              {new Date(dateCompleted).toLocaleDateString(undefined, {
-                weekday: 'long',
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })}
-            </Text>
-          </GridItem>
-        )}
-        <GridItem justifySelf={{ base: 'start', md: 'end' }}>
-          <Badge colorScheme={statusColors[status]} fontSize="md" px={3} py={1}>
-            {status.toUpperCase()}
-          </Badge>
-        </GridItem>
-        <GridItem>
+              <Text fontSize="lg" fontWeight="medium">
+                {endDateStr}
+              </Text>
+            </GridItem>
+            {dateCompleted && (
+              <GridItem>
+                <HStack>
+                  <Clock size={16} />
+                  <Text fontSize="sm" color={subtleColor}>
+                    completed on
+                  </Text>
+                </HStack>
+                <Text fontSize="lg" fontWeight="medium">
+                  {new Date(dateCompleted).toLocaleDateString(undefined, {
+                    weekday: 'long',
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </Text>
+              </GridItem>
+            )}
+          </Grid>
+        </Box>
+
+        <Flex gap={4} align="flex-start">
+          {!DISABLE_INTERVIEW_STATUS_FLAG && (
+            <Badge
+              colorScheme={statusColors[status]}
+              fontSize="md"
+              px={3}
+              py={1}
+            >
+              {status.toUpperCase()}
+            </Badge>
+          )}
           <Button onClick={onOpen}>Report Interviewer or Interviewee</Button>
-        </GridItem>
-      </Grid>
+        </Flex>
+      </Flex>
 
       <Divider />
 

--- a/src/pages/ViewInterviewsPage.tsx
+++ b/src/pages/ViewInterviewsPage.tsx
@@ -22,6 +22,7 @@ import { getInterviewsHydratedForUser } from '../services/interview';
 import { useAuth } from '../hooks/useAuth';
 import { devPrint, resolveName } from '../components/utils/RandomUtils';
 import { ViewInterviewPage } from './ViewInterviewPage';
+import { DISABLE_INTERVIEW_STATUS_FLAG } from '../feature-flag';
 
 interface DateRange {
   start: string;
@@ -87,7 +88,9 @@ const InterviewPreview: React.FC<InterviewPreviewProps> = ({ interview }) => {
               })}
             </Text>
           </HStack>
-          <InterviewStatusBadge status={interview.status} />
+          {!DISABLE_INTERVIEW_STATUS_FLAG && (
+            <InterviewStatusBadge status={interview.status} />
+          )}
         </Flex>
 
         {/* participants */}
@@ -251,22 +254,24 @@ export const ViewInterviewsPage: React.FC = () => {
               }
             />
           </Box>
-          <Box flex="1" minW="200px">
-            <Text mb={2} fontSize="sm">
-              Status
-            </Text>
-            <Select
-              value={statusFilter}
-              onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                setStatusFilter(e.target.value as 'all' | Status)
-              }
-            >
-              <option value="all">All Status</option>
-              <option value="active">Active</option>
-              <option value="pending">Pending</option>
-              <option value="inactive">Inactive</option>
-            </Select>
-          </Box>
+          {!DISABLE_INTERVIEW_STATUS_FLAG && (
+            <Box flex="1" minW="200px">
+              <Text mb={2} fontSize="sm">
+                Status
+              </Text>
+              <Select
+                value={statusFilter}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  setStatusFilter(e.target.value as 'all' | Status)
+                }
+              >
+                <option value="all">All Status</option>
+                <option value="active">Active</option>
+                <option value="pending">Pending</option>
+                <option value="inactive">Inactive</option>
+              </Select>
+            </Box>
+          )}
         </HStack>
 
         {/* results */}


### PR DESCRIPTION
Author: Elijah

## What changes were made?

Hid the interview status and made report popup look better 

## Why are these changes important/necessary?

- we aren't updating, nor letting users update status
- report needs to look good since it's user facing

## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!

### Before
<img width="864" alt="Screenshot 2024-11-28 at 1 23 58 PM" src="https://github.com/user-attachments/assets/9330ba7e-f145-4c09-b353-ceffe5b0b33d">
<img width="799" alt="Screenshot 2024-11-28 at 1 24 52 PM" src="https://github.com/user-attachments/assets/d1bac397-692a-422c-a496-c82ebc54179c">
<img width="962" alt="Screenshot 2024-11-28 at 1 25 11 PM" src="https://github.com/user-attachments/assets/8def3dd2-3634-40b8-8809-204c7924704b">

### After
<img width="887" alt="Screenshot 2024-11-28 at 1 28 33 PM" src="https://github.com/user-attachments/assets/1ecbc470-4f06-42be-9dc9-02d8907ecb43">
<img width="1077" alt="Screenshot 2024-11-28 at 1 25 55 PM" src="https://github.com/user-attachments/assets/6e90cd12-54af-4cf1-8c59-de0c83dc2008">
<img width="914" alt="Screenshot 2024-11-28 at 1 26 16 PM" src="https://github.com/user-attachments/assets/64328872-6fbe-46a8-bd6c-4cec8fd3746c">
