### PR TITLE
dont redirect on refresh when authentcated

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   Box,
   Flex,
@@ -43,6 +43,23 @@ interface NavBarProps {
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   const { isAuthenticated, isAdmin, loading, member, isVerified } = useAuth();
+
+  const navigate = useNavigate();
+  useEffect(() => {
+    let redirectTimeout: NodeJS.Timeout;
+
+    if (!loading && isAuthenticated && !isVerified) {
+      redirectTimeout = setTimeout(() => {
+        navigate('/auth');
+      }, 1000);
+    }
+
+    return () => {
+      if (redirectTimeout) {
+        clearTimeout(redirectTimeout);
+      }
+    };
+  }, [isAuthenticated, isVerified, loading, navigate]);
 
   if (loading) {
     return (

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -46,19 +46,9 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
 
   const navigate = useNavigate();
   useEffect(() => {
-    let redirectTimeout: NodeJS.Timeout;
-
-    if (!loading && isAuthenticated && !isVerified) {
-      redirectTimeout = setTimeout(() => {
-        navigate('/auth');
-      }, 1000);
+    if (!loading && (!isAuthenticated || !isVerified)) {
+      navigate('/auth');
     }
-
-    return () => {
-      if (redirectTimeout) {
-        clearTimeout(redirectTimeout);
-      }
-    };
   }, [isAuthenticated, isVerified, loading, navigate]);
 
   if (loading) {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import {
   Box,
   Flex,
@@ -43,16 +43,6 @@ interface NavBarProps {
 
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   const { isAuthenticated, isAdmin, loading, member, isVerified } = useAuth();
-  const navigate = useNavigate();
-  useEffect(() => {
-    if (!isAuthenticated) {
-      return;
-    }
-
-    if (!isVerified) {
-      navigate('/auth');
-    }
-  }, [isAuthenticated, isVerified, navigate]);
 
   if (loading) {
     return (

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -66,6 +66,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           const groups = mem.groups?.map((value) => value.name);
           setIsAdmin(groups?.includes('is_admin') ?? false);
           setIsVerified(groups?.includes('is_verified') ?? false);
+          setLoading(false);
         })
         .catch((err) => {
           devPrint('Failed to get current user:', err);
@@ -80,7 +81,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     try {
       await api.get('/auth/session/');
       setIsAuthenticated(true);
-      setLoading(false);
     } catch (err) {
       setIsAuthenticated(false);
       setLoading(false);


### PR DESCRIPTION
Author: Elijah

## What changes were made?

Fix the annoying redirect when auth is loading. Just add timeout before

Used to go `/auth` -> `/home` every refresh, now stays on same page

## Why are these changes important/necessary?

## (If applicable) Screenshots of your changes. Providing an “old vs. new” comparison would be great!
